### PR TITLE
Fix flow meter setup issues

### DIFF
--- a/setup_flow_meter.py
+++ b/setup_flow_meter.py
@@ -129,20 +129,28 @@ Common Flow Meters:
   - YF-B1: ~1800 pulses/L, 1-25 L/min flow rate
 
 Wiring (typical 3-wire flow meter):
-  - Red wire (VCC)    -> Raspberry Pi 5V (pin 2 or 4)
-  - Black wire (GND)  -> Raspberry Pi GND (pin 6, 9, 14, 20, 25, 30, 34, or 39)
-  - Yellow wire (SIG) -> Raspberry Pi GPIO pin (default: GPIO 18, pin 12)
+  - Red wire (VCC)    -> Raspberry Pi 5V (physical pin 2 or 4)
+  - Black wire (GND)  -> Raspberry Pi GND (physical pin 6, 9, 14, 20, 25, 30, 34, or 39)
+  - Yellow wire (SIG) -> Raspberry Pi GPIO pin (default: GPIO 18 = physical pin 12)
+
+IMPORTANT - Pin Numbering:
+  This script uses BCM (Broadcom) GPIO numbering, NOT physical pin numbers!
+  - When asked for GPIO pin, use BCM number (e.g., 18, 4, 17)
+  - Physical pin 7  = GPIO 4  (BCM)
+  - Physical pin 12 = GPIO 18 (BCM) <- default
+  - Physical pin 26 = GPIO 7  (BCM)
 
 Optional Pull-up Resistor:
   - 10k ohm resistor between Signal (Yellow) and VCC (Red)
   - Some flow meters have built-in pull-ups
 
-Raspberry Pi 2 GPIO Pinout (relevant pins):
-  Pin 2:  5V
-  Pin 4:  5V  
-  Pin 6:  GND
-  Pin 12: GPIO 18 (default signal pin)
-  Pin 14: GND
+Raspberry Pi 4 GPIO Pinout (relevant pins):
+  Physical Pin 2:  5V
+  Physical Pin 4:  5V
+  Physical Pin 6:  GND
+  Physical Pin 7:  GPIO 4  (BCM)
+  Physical Pin 12: GPIO 18 (BCM) <- default signal pin
+  Physical Pin 14: GND
 
 Installation:
   1. Power off Raspberry Pi


### PR DESCRIPTION
- Fixed critical naming conflict where stop_monitoring was both an Event object and a method name
- Renamed Event objects to _stop_event in both FlowMeter and KegFlowTracker classes
- Updated GPIO pin documentation to clarify BCM vs physical pin numbering for Raspberry Pi 4
- Added clear explanation that physical pin 7 = GPIO 4 in BCM mode

This resolves the "_Event' object not callable" error during flow meter calibration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames threading Event to `_stop_event` in flow tracking classes to avoid name/method conflict and updates setup instructions to clearly distinguish BCM vs physical pin numbering (RPi 4).
> 
> - **Flow tracking (`flow_meter.py`)**:
>   - Rename threading `Event` from `stop_monitoring` to `_stop_event` in `FlowMeter` and `KegFlowTracker` with all usages updated (`start/stop` methods and loops).
>   - Simulation loop and pour monitoring now check `_stop_event` for shutdown.
> - **Setup script (`setup_flow_meter.py`)**:
>   - Clarify wiring docs and BCM vs physical pin numbering; add Raspberry Pi 4 pinout examples and mappings (e.g., physical pin 7 = GPIO 4, physical pin 12 = GPIO 18).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc858af09c15a66150efd810668cab802a6a7ac7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->