### PR TITLE
Fix Python 2 input() parsing error in calibration

### DIFF
--- a/setup_flow_meter.py
+++ b/setup_flow_meter.py
@@ -59,13 +59,13 @@ def interactive_calibration(gpio_pin=18):
     print("  - A measuring cup (500ml or 1L recommended)")
     print("  - Water or another liquid")
     print("  - The flow meter installed in your system")
-    
-    input("\nPress Enter when ready to start...")
+
+    raw_input("\nPress Enter when ready to start...")
     
     # Get known volume
     while True:
         try:
-            volume_ml = float(input("\nEnter the volume you'll pour (in ml): "))
+            volume_ml = float(raw_input("\nEnter the volume you'll pour (in ml): "))
             if volume_ml > 0:
                 break
             print("Please enter a positive volume.")
@@ -85,9 +85,9 @@ def interactive_calibration(gpio_pin=18):
         flow_meter.start_monitoring()
         print("\n[POUR] Pour exactly %sml through the flow meter now..." % volume_ml)
         print("Press Enter when finished pouring.")
-        
+
         start_pulses = flow_meter.pulse_count
-        input()
+        raw_input()
         end_pulses = flow_meter.pulse_count
         
         calibration_pulses = end_pulses - start_pulses


### PR DESCRIPTION
- Changed all input() calls to raw_input() for Python 2 compatibility
- In Python 2, input() evaluates input as code, causing EOF errors on empty input
- raw_input() correctly returns string input without evaluation

This fixes the "unexpected EOF while parsing" error when pressing Enter during calibration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `input()` with `raw_input()` in `interactive_calibration` to fix Python 2 input parsing issues.
> 
> - **Calibration CLI (`setup_flow_meter.py`)**:
>   - Replace `input()` with `raw_input()` in `interactive_calibration` prompts (start prompt, volume entry, and pour-finish prompt) for Python 2 compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba449abf051fb11b71a2a301c56c6cf591bd58db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->